### PR TITLE
Add auto-generated database URL with validation to SqlAlchemyCo…

### DIFF
--- a/archipy/configs/config_template.py
+++ b/archipy/configs/config_template.py
@@ -249,9 +249,9 @@ class SqlAlchemyConfig(BaseModel):
 
             # Extract username and password
             if parsed.netloc:
-                auth_part = parsed.netloc.split('@')[0] if '@' in parsed.netloc else ''
-                if ':' in auth_part:
-                    username, password = auth_part.split(':', 1)
+                auth_part = parsed.netloc.split("@")[0] if "@" in parsed.netloc else ""
+                if ":" in auth_part:
+                    username, password = auth_part.split(":", 1)
                     if self.USERNAME is None:
                         self.USERNAME = username
                     if self.PASSWORD is None:
@@ -260,9 +260,9 @@ class SqlAlchemyConfig(BaseModel):
                     self.USERNAME = auth_part
 
             # Extract host and port
-            host_part = parsed.netloc.split('@')[-1] if '@' in parsed.netloc else parsed.netloc
-            if ':' in host_part:
-                host, port_str = host_part.split(':', 1)
+            host_part = parsed.netloc.split("@")[-1] if "@" in parsed.netloc else parsed.netloc
+            if ":" in host_part:
+                host, port_str = host_part.split(":", 1)
                 if self.HOST is None:
                     self.HOST = host
                 if self.PORT is None:
@@ -274,7 +274,7 @@ class SqlAlchemyConfig(BaseModel):
                 self.HOST = host_part
 
             # Extract database name
-            if self.DATABASE is None and parsed.path and parsed.path.startswith('/'):
+            if self.DATABASE is None and parsed.path and parsed.path.startswith("/"):
                 self.DATABASE = parsed.path[1:]
 
         return self


### PR DESCRIPTION
## Description

This PR adds automatic generation of database URLs with proper validation to the SQLAlchemy configuration. It implements a custom `PostgresDsn` class that extends Pydantic's `AnyUrl`, providing validation of PostgreSQL connection strings with support for various PostgreSQL-specific drivers.

The implementation includes two main features:
1. Auto-generation of connection URLs when component parameters (username, password, host, port, database) are provided
2. Extraction of component parts from a provided URL to populate missing fields

This makes the configuration more flexible and robust, allowing users to specify either individual components or a complete connection string.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Tested URL generation with all components provided
- [x] Tested URL validation with valid PostgreSQL schemes
- [x] Tested URL validation with invalid schemes
- [x] Tested component extraction from valid URLs
- [x] Tested with and without password in the connection string

Sample code for testing:
```python
# Test with individual components
db_config = SqlAlchemyConfig(
    USERNAME="postgres", 
    PASSWORD="password123", 
    HOST="localhost", 
    PORT=5432, 
    DATABASE="mydb"
)
assert db_config.DB_URL is not None

# Test with connection string
db_config = SqlAlchemyConfig(
    DB_URL="postgresql+psycopg://user:pass@dbhost:5432/otherdb"
)
assert db_config.USERNAME == "user"
assert db_config.PASSWORD == "pass"
assert db_config.HOST == "dbhost"
assert db_config.PORT == 5432
assert db_config.DATABASE == "otherdb"
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional context
This implementation follows Python 3.13 conventions by using Union syntax (`|`) and proper type hints throughout.
Resolves #28 
