### PR TITLE
Fix: Fixed sql alchemy sort mixin

### DIFF
--- a/archipy/adapters/orm/sqlalchemy/adapters.py
+++ b/archipy/adapters/orm/sqlalchemy/adapters.py
@@ -14,7 +14,7 @@ from archipy.configs.config_template import SqlAlchemyConfig
 from archipy.models.dtos.pagination_dto import PaginationDTO
 from archipy.models.dtos.sort_dto import SortDTO
 from archipy.models.entities import BaseEntity
-from archipy.models.errors.custom_errors import InternalError, InvalidEntityTypeError
+from archipy.models.errors.custom_errors import InternalError, InvalidArgumentError, InvalidEntityTypeError
 from archipy.models.types.base_types import FilterOperationType
 from archipy.models.types.sort_order_type import SortOrderType
 
@@ -120,9 +120,13 @@ class SqlAlchemySortMixin:
         else:
             sort_column = sort_info.column
 
-        if sort_info.order == SortOrderType.ASCENDING:
+        order_value: str = sort_info.order.value if isinstance(sort_info.order, Enum) else sort_info.order
+        if order_value == SortOrderType.ASCENDING.value:
             return query.order_by(sort_column.asc())
-        return query.order_by(sort_column.desc())
+        elif order_value == SortOrderType.DESCENDING.value:
+            return query.order_by(sort_column.desc())
+        else:
+            raise InvalidArgumentError(argument_name="sort_info.order")
 
 
 class SqlAlchemyAdapter(SqlAlchemyPort, SqlAlchemyPaginationMixin, SqlAlchemySortMixin):


### PR DESCRIPTION
## Description

This change fixes an issue in the `SqlAlchemySortMixin` class where the sorting logic did not properly handle `SortOrderType` when it was provided as an `Enum`. The original code assumed `sort_info.order` was a string and directly compared it to `SortOrderType.ASCENDING`, which caused incorrect sorting behavior when an `Enum` was passed. The updated code extracts the `value` from the `Enum` (if applicable) and compares it against the `value` of `SortOrderType.ASCENDING` and `SortOrderType.DESCENDING`. Additionally, it introduces explicit error handling for invalid `sort_info.order` values by raising an `InvalidArgumentError`.

This fix ensures that sorting works correctly regardless of whether `sort_info.order` is passed as a string or an `Enum`, improving robustness and reliability of the sorting functionality.

Fixes # (Sorting issue with Enum-based SortOrderType in SqlAlchemySortMixin)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Additional context

The change was motivated by bug reports indicating that sorting failed when `SortOrderType` was passed as an `Enum` in certain API endpoints. The fix maintains backward compatibility with string-based inputs while adding support for `Enum`-based inputs and improving error handling.