### PR TITLE
Add client role creation functionality to Keycloak adapter

### DIFF
--- a/archipy/adapters/keycloak/ports.py
+++ b/archipy/adapters/keycloak/ports.py
@@ -219,6 +219,10 @@ class KeycloakPort:
         """Delete a user from Keycloak by their ID."""
         raise NotImplementedError
 
+    def create_client_role(self, client_id: str, role_name: str, description: str | None = None) -> dict[str, Any]:
+        """Create a new client role."""
+        raise NotImplementedError
+
 
 class AsyncKeycloakPort:
     """Asynchronous interface for Keycloak operations providing a standardized access pattern.
@@ -422,4 +426,8 @@ class AsyncKeycloakPort:
     @abstractmethod
     async def delete_user(self, user_id: str) -> None:
         """Delete a user from Keycloak by their ID."""
+        raise NotImplementedError
+
+    async def create_client_role(self, client_id: str, role_name: str, description: str | None = None) -> dict[str, Any]:
+        """Create a new client role."""
         raise NotImplementedError


### PR DESCRIPTION
# Add client role creation functionality to Keycloak adapter

## Feature Description
This PR adds the ability to create client-specific roles in Keycloak through both the synchronous and asynchronous adapters.

## Problem Statement
The current Keycloak adapter implementation supports creating realm roles but lacks the ability to create client-specific roles. This limitation requires developers to use external tools or the Keycloak admin console to manage client roles, which prevents programmatic role management within applications.

## Implemented Solution
The implementation adds:
1. `create_client_role` method to both `KeycloakPort` and `AsyncKeycloakPort` protocols
2. Implementation of the method in both `KeycloakAdapter` and `AsyncKeycloakAdapter` classes

## Usage Example
```python
# Synchronous
client_role = keycloak.create_client_role(
    client_id="my-client",
    role_name="new-client-role",
    description="Client role description"
)

# Asynchronous
client_role = await async_keycloak.create_client_role(
    client_id="my-client",
    role_name="new-client-role",
    description="Client role description"
)
```

Fixes #40 