### PR TITLE
Fix invalid import of non-existent `ElasticsearchConfig` in config_template

### DIFF
--- a/archipy/configs/base_config.py
+++ b/archipy/configs/base_config.py
@@ -13,7 +13,6 @@ from archipy.configs.config_template import (
     DatetimeConfig,
     ElasticSearchAPMConfig,
     ElasticSearchConfig,
-    ElasticsearchConfig,
     EmailConfig,
     FastAPIConfig,
     FileConfig,


### PR DESCRIPTION
### Problem
The `config_template` module attempts to import `ElasticsearchConfig`, which is not defined anywhere in the codebase. This causes an `ImportError` during import time, breaking any modules that rely on it.

### Solution
This PR removes the import of `ElasticsearchConfig` from `archipy.configs.config_template`.

### Impact
- Prevents runtime errors due to invalid import.

### Checklist
- [x] Removed invalid import
- [x] Verified no usage of `ElasticsearchConfig` elsewhere in the code