### PR TITLE
Refactor datetime handling: naive get_datetime_now and func.now() for entity timestamps

### DIFF
--- a/archipy/helpers/utils/datetime_utils.py
+++ b/archipy/helpers/utils/datetime_utils.py
@@ -280,12 +280,12 @@ class DatetimeUtils:
 
     @classmethod
     def get_datetime_now(cls) -> datetime:
-        """Gets the current local datetime with timezone information.
+        """Gets the current local datetime.
 
         Returns:
-            datetime: The current local datetime with UTC timezone.
+            datetime: The current local datetime.
         """
-        return datetime.now(UTC)
+        return datetime.now()
 
     @classmethod
     def get_datetime_utc_now(cls) -> datetime:

--- a/archipy/models/entities/sqlalchemy/base_entities.py
+++ b/archipy/models/entities/sqlalchemy/base_entities.py
@@ -2,9 +2,8 @@ from datetime import datetime
 from typing import ClassVar
 
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, text
-from sqlalchemy.orm import DeclarativeBase, Mapped, Synonym
+from sqlalchemy.orm import DeclarativeBase, Mapped, Synonym, func
 
-from archipy.helpers.utils.base_utils import BaseUtils
 
 PK_COLUMN_NAME = "pk_uuid"
 
@@ -22,7 +21,7 @@ class BaseEntity(DeclarativeBase):
     """
 
     __abstract__ = True
-    created_at: Mapped[datetime] = Column(DateTime(), server_default=text("CURRENT_TIMESTAMP"), nullable=False)
+    created_at: Mapped[datetime] = Column(DateTime(), server_default=func.now(), nullable=False)
 
     @classmethod
     def _is_abstract(cls) -> bool:
@@ -120,16 +119,11 @@ class UpdatableMixin:
 
     __abstract__ = True
 
-    @staticmethod
-    def _make_naive(dt: datetime) -> datetime:
-        """Convert a timezone-aware datetime to naive by removing timezone info."""
-        return dt.replace(tzinfo=None) if dt.tzinfo else dt
-
     updated_at = Column(
         DateTime(),
-        server_default=text("CURRENT_TIMESTAMP"),
+        server_default=func.now(),
         nullable=False,
-        onupdate=lambda: UpdatableMixin._make_naive(BaseUtils.get_datetime_now()),
+        onupdate=func.now(),
     )
 
 


### PR DESCRIPTION

### Changes

- **DatetimeUtils.get_datetime_now** now returns a naive (timezone-unaware) local datetime, instead of a timezone-aware UTC datetime.
- **base_entities**: All timestamp columns now use `func.now()` for both `server_default` and `onupdate`, ensuring that timestamps are generated by the database rather than the application.