### PR TITLE
Refactor: Ensure correct type for PostgresDsn instantiation

### DIFF
--- a/archipy/configs/config_template.py
+++ b/archipy/configs/config_template.py
@@ -432,8 +432,8 @@ class PostgresSQLAlchemyConfig(SQLAlchemyConfig):
 
         if all([self.USERNAME, self.HOST, self.PORT, self.DATABASE]):
             password_part = f":{self.PASSWORD}" if self.PASSWORD else ""
-            self.POSTGRES_DSN = (
-                f"{self.DRIVER_NAME}://{self.USERNAME}{password_part}@{self.HOST}:{self.PORT}/{self.DATABASE}"
+            self.POSTGRES_DSN = PostgresDsn(
+                url=f"{self.DRIVER_NAME}://{self.USERNAME}{password_part}@{self.HOST}:{self.PORT}/{self.DATABASE}",
             )
         return self
 


### PR DESCRIPTION
### Summary

This PR resolves a `PydanticSerializationUnexpectedValue` warning that occurs when building the PostgreSQL connection DSN.

### The Problem

The code was assigning a raw formatted string to a field that is typed as `pydantic.networks.PostgresDsn`. This caused Pydantic to raise the following warning during serialization:

```bash
pydantic/main.py:463: UserWarning: Pydantic serializer warnings:
PydanticSerializationUnexpectedValue(Expected <class 'pydantic.networks.PostgresDsn'> but got <class 'str'> with value '...' - serialized value may not be as expected.)
```

### The Solution

The fix is to explicitly instantiate the `PostgresDsn` class with the connection string. This ensures that the field holds an object of the correct type, leverages Pydantic's validation, and silences the warning.