### PR TITLE
feat(sqlalchemy): Make connect_args configurable via config object

### DIFF
--- a/archipy/adapters/base/sqlalchemy/session_managers.py
+++ b/archipy/adapters/base/sqlalchemy/session_managers.py
@@ -109,7 +109,7 @@ class BaseSQLAlchemySessionManager(SessionManagerPort):
                 pool_use_lifo=configs.POOL_USE_LIFO,
                 query_cache_size=configs.QUERY_CACHE_SIZE,
                 max_overflow=configs.POOL_MAX_OVERFLOW,
-                connect_args=self._get_connect_args(),
+                connect_args=self._get_connect_args(configs),
             )
         except SQLAlchemyError as e:
             if "configuration" in str(e).lower():
@@ -135,13 +135,13 @@ class BaseSQLAlchemySessionManager(SessionManagerPort):
         """
         pass
 
-    def _get_connect_args(self) -> dict:
+    def _get_connect_args(self, configs: SQLAlchemyConfig) -> dict:
         """Return additional connection arguments for the engine.
 
         Returns:
             A dictionary of connection arguments (default is empty).
         """
-        return {}
+        return configs.CONNECT_ARGS or {}
 
     def _get_session_generator(self) -> scoped_session:
         """Create a scoped session factory for synchronous sessions.
@@ -295,7 +295,7 @@ class AsyncBaseSQLAlchemySessionManager(AsyncSessionManagerPort):
                 pool_use_lifo=configs.POOL_USE_LIFO,
                 query_cache_size=configs.QUERY_CACHE_SIZE,
                 max_overflow=configs.POOL_MAX_OVERFLOW,
-                connect_args=self._get_connect_args(),
+                connect_args=self._get_connect_args(configs),
             )
         except SQLAlchemyError as e:
             if "configuration" in str(e).lower():
@@ -321,13 +321,13 @@ class AsyncBaseSQLAlchemySessionManager(AsyncSessionManagerPort):
         """
         pass
 
-    def _get_connect_args(self) -> dict:
+    def _get_connect_args(self, configs: SQLAlchemyConfig) -> dict:
         """Return additional connection arguments for the engine.
 
         Returns:
             A dictionary of connection arguments (default is empty).
         """
-        return {}
+        return configs.CONNECT_ARGS or {}
 
     def _get_session_generator(self) -> async_scoped_session:
         """Create an async scoped session factory.

--- a/archipy/configs/config_template.py
+++ b/archipy/configs/config_template.py
@@ -6,7 +6,7 @@ and more.
 """
 
 import logging
-from typing import Literal, Self
+from typing import Any, Literal, Self
 from urllib.parse import urlparse
 
 from pydantic import BaseModel, Field, PostgresDsn, SecretStr, model_validator
@@ -395,6 +395,7 @@ class SQLAlchemyConfig(BaseModel):
     PORT: int | None = Field(default=5432, description="Database port")
     QUERY_CACHE_SIZE: int = Field(default=500, description="Size of the query cache")
     USERNAME: str | None = Field(default=None, description="Database username")
+    CONNECT_ARGS: dict[str, Any] = {}
 
 
 class SQLiteSQLAlchemyConfig(SQLAlchemyConfig):


### PR DESCRIPTION
# Summary

This PR refactors the BaseSQLAlchemySessionManager and AsyncBaseSQLAlchemySessionManager to allow connect_args for the SQLAlchemy engine to be provided dynamically through the configuration object.