### PR TITLE
Potential fix for code scanning alert no. 1062: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   behave-tests:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/SyntaxArc/ArchiPy/security/code-scanning/1062](https://github.com/SyntaxArc/ArchiPy/security/code-scanning/1062)

To fix the problem, we need to add an explicit `permissions:` block. The best practice is to define this at the job level (so it doesn't inadvertently restrict unrelated jobs) or at the workflow root if all jobs need the same. In this workflow, there is a single job, so either approach is fine, but for minimal change, we'll add `permissions:` just above `runs-on:` inside the `behave-tests:` job. This block should grant only the least necessary privileges, which for test jobs is usually `contents: read`, allowing read-only access to repository files so the workflow can check out code. No other permissions appear to be required for this workflow.

Edit `.github/workflows/tests.yml` and insert:
```yaml
permissions:
  contents: read
```
above the `runs-on: ubuntu-latest` line inside the `behave-tests:` job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
