### PR TITLE
Potential fix for code scanning alert no. 1063: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,6 @@
 name: Build and Publish
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/SyntaxArc/ArchiPy/security/code-scanning/1063](https://github.com/SyntaxArc/ArchiPy/security/code-scanning/1063)

The best way to remediate this problem is to add an explicit `permissions` block to either the root of the workflow or specifically to the `publish` job. Since the workflow appears to only require reading repository contents (to check out code) and does not appear to require write actions against the repo via the GITHUB_TOKEN, the minimum recommended block would be `permissions: contents: read`. You should add this either as a workflow-level (at the top, beneath `name:` and before or after `on:`) or job-level (directly under `publish:`). To apply least privilege everywhere, it is best to set it at the workflow level, but setting it at the job level is also acceptable.

Edit `.github/workflows/publish.yml` and add:

```yaml
permissions:
  contents: read
```

just after line 1 or 2.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
