### PR TITLE
Potential fix for code scanning alert no. 1064: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   lint:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5


### PR DESCRIPTION
Potential fix for [https://github.com/SyntaxArc/ArchiPy/security/code-scanning/1064](https://github.com/SyntaxArc/ArchiPy/security/code-scanning/1064)

The best way to fix this problem is to add a `permissions` block at the appropriate level in the workflow file to limit the permissions of GITHUB_TOKEN to only what is required. Since the lint job only needs to read the code (e.g., to check out files, gather changed files, run the linter), it does not need write permissions. Therefore, adding `permissions: contents: read` either at the workflow root (to apply to all jobs) or within the `lint` job (to apply only there) is ideal. For clarity and future extensibility, placing it at the job-level ensures explicitness, but root-level is also acceptable if there’s only one job. You'll need to insert:

```
permissions:
  contents: read
```
either just after `name: Lint` (root-level), or on line 11, before `runs-on: ubuntu-latest` (job-level).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
