### PR TITLE
add enforce_attribute decorator

### DIFF
--- a/archipy/helpers/decorators/attribute_enforce.py
+++ b/archipy/helpers/decorators/attribute_enforce.py
@@ -1,0 +1,41 @@
+from collections.abc import Callable
+
+
+def enforce_attributes[T](attrs: tuple[tuple[tuple[str, ...], ...], ...]) -> Callable[[type[T]], type[T]]:
+    """A decorator that checks existence of given attributes on a class.
+
+    Args:
+        attrs (`tuple[tuple[tuple[str, ...], ...], ...]`): A tuple of tuples of tuples of attribute names, of which one
+            shall exist as class variable or annotation.
+
+    Returns:
+        type: The validated class.
+
+    Raises:
+        AttributeError: if one or more of the required attributes don't exist on the class.
+
+    Example:
+        To use this decorator, apply it to a class.
+
+        ```python
+        manager_attrs = ("created_by", "created_by_uuid")
+        admin_attrs = ("created_by_admin", "created_by_admin_uuid")
+
+        @ensure_attrs()
+        class CustomType:
+            created_by: UUID
+            created_by_admin_uuid: UUID
+        ```
+    """
+
+    def validator(kls: type[T]) -> type[T]:
+        if "__annotations__" in (existing_attrs := set(vars(kls).keys())):
+            existing_attrs.update(vars(kls)["__annotations__"])
+        for category in attrs:
+            for group in category:
+                if len(existing_attrs.intersection(group)) == 0:
+                    error_message = f"none of {group} is present on {kls.__name__}"
+                    raise AttributeError(error_message)
+        return kls
+
+    return validator

--- a/archipy/helpers/decorators/attribute_enforce.py
+++ b/archipy/helpers/decorators/attribute_enforce.py
@@ -21,7 +21,7 @@ def enforce_attributes[T](attrs: tuple[tuple[tuple[str, ...], ...], ...]) -> Cal
         manager_attrs = ("created_by", "created_by_uuid")
         admin_attrs = ("created_by_admin", "created_by_admin_uuid")
 
-        @ensure_attrs()
+        @ensure_attrs((admin_attrs, manager_attrs))
         class CustomType:
             created_by: UUID
             created_by_admin_uuid: UUID

--- a/archipy/helpers/decorators/attribute_enforce.py
+++ b/archipy/helpers/decorators/attribute_enforce.py
@@ -31,11 +31,12 @@ def enforce_attributes[T](attrs: tuple[tuple[tuple[str, ...], ...], ...]) -> Cal
     def validator(kls: type[T]) -> type[T]:
         if "__annotations__" in (existing_attrs := set(vars(kls).keys())):
             existing_attrs.update(vars(kls)["__annotations__"])
-        for category in attrs:
-            for group in category:
-                if len(existing_attrs.intersection(group)) == 0:
-                    error_message = f"none of {group} is present on {kls.__name__}"
-                    raise AttributeError(error_message)
+        if not getattr(kls, "__abstract__", False):
+            for category in attrs:
+                for group in category:
+                    if len(existing_attrs.intersection(group)) == 0:
+                        error_message = f"none of {group} is present on {kls.__name__}"
+                        raise AttributeError(error_message)
         return kls
 
     return validator


### PR DESCRIPTION
## Description

This pull request attempts to fix a bug that is not yet reported. The bug is caused by how `EntityAttributeChecker` is designed & its wrong assumption about multiple inheritance in python. Python uses `.__mro__` to solve [the diamond problem](https://en.wikipedia.org/wiki/Multiple_inheritance#The_diamond_problem). All defined mixins implement `__init_subclass__` & use it as a mechanism to enforce their required fields, with the assumption that all of the implementations will be called when a subclass is initialized. While the only implementation which gets called is the first one that appears in "MRO".

I have provided another way to force attribute existence; but haven't actually applied it on entity definitions because I'm not sure how it fits the overall architecture. (and wether it does or doesn't!)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings

## Additional context

### Reproduction of bug of `EntityAttributeChecker`

```py
from archipy.models.entities.sqlalchemy.base_entities import ManagerEntity, ManagerMixin



class CustomEntity(ManagerEntity):
    ...


if __name__ == "__main__":
    # no exception is raised while non of attributes in
    # `ManagerMixin.required_any` exist on the child class
    print(vars(CustomEntity))
```