### PR TITLE
Changed sqlalchemy adapter base model typing

### DIFF
--- a/archipy/adapters/base/sqlalchemy/adapters.py
+++ b/archipy/adapters/base/sqlalchemy/adapters.py
@@ -165,7 +165,7 @@ class SQLAlchemySortMixin:
     """
 
     @staticmethod
-    def _apply_sorting(entity: type[BaseEntity], query: Select, sort_info: SortDTO | None) -> Select:
+    def _apply_sorting(entity: type[T], query: Select, sort_info: SortDTO | None) -> Select:
         """Apply sorting to a SQLAlchemy query.
 
         Args:
@@ -238,12 +238,12 @@ class BaseSQLAlchemyAdapter[ConfigT: SQLAlchemyConfig](
     @override
     def execute_search_query(
         self,
-        entity: type[BaseEntity],
+        entity: type[T],
         query: Select,
         pagination: PaginationDTO | None = None,
         sort_info: SortDTO | None = None,
         has_multiple_entities: bool = False,
-    ) -> tuple[list[BaseEntity], int]:
+    ) -> tuple[list[T], int]:
         """Execute a search query with pagination and sorting.
 
         Args:
@@ -398,7 +398,7 @@ class BaseSQLAlchemyAdapter[ConfigT: SQLAlchemyConfig](
             return result
 
     @override
-    def delete(self, entity: BaseEntity) -> None:
+    def delete(self, entity: T) -> None:
         """Delete an entity from the database.
 
         Args:
@@ -427,7 +427,7 @@ class BaseSQLAlchemyAdapter[ConfigT: SQLAlchemyConfig](
             self._handle_db_exception(e, self.session_manager._get_database_name())
 
     @override
-    def bulk_delete(self, entities: list[BaseEntity]) -> None:
+    def bulk_delete(self, entities: list[T]) -> None:
         """Delete multiple entities from the database.
 
         Args:
@@ -549,12 +549,12 @@ class AsyncBaseSQLAlchemyAdapter[ConfigT: SQLAlchemyConfig](
     @override
     async def execute_search_query(
         self,
-        entity: type[BaseEntity],
+        entity: type[T],
         query: Select,
         pagination: PaginationDTO | None,
         sort_info: SortDTO | None = None,
         has_multiple_entities: bool = False,
-    ) -> tuple[list[BaseEntity], int]:
+    ) -> tuple[list[T], int]:
         """Execute a search query with pagination and sorting.
 
         Args:
@@ -739,7 +739,7 @@ class AsyncBaseSQLAlchemyAdapter[ConfigT: SQLAlchemyConfig](
             self._handle_db_exception(e, self.session_manager._get_database_name())
 
     @override
-    async def bulk_delete(self, entities: list[BaseEntity]) -> None:
+    async def bulk_delete(self, entities: list[T]) -> None:
         """Delete multiple entities from the database.
 
         Args:


### PR DESCRIPTION
# Pull Request: Improve SQLAlchemy Adapter Type Safety

## Description

This PR improves type safety in the SQLAlchemy base adapter by replacing generic `BaseEntity` type annotations with the more specific generic type variable `T` that is bound to `BaseEntity`. This change enhances type checking and provides better IDE support while maintaining backward compatibility.

### Changes Made

- **Enhanced Type Safety**: Replaced `BaseEntity` with `T` (TypeVar bound to BaseEntity) in method signatures across both sync and async SQLAlchemy adapters
- **Improved Generic Type Support**: Updated method signatures in `BaseSQLAlchemyAdapter` and `AsyncBaseSQLAlchemyAdapter` to use the generic type variable `T`
- **Better IDE Support**: Enhanced IntelliSense and type checking capabilities for developers using these adapters

### Specific Method Updates

The following methods now use proper generic typing:
- `_apply_sorting()` in `SQLAlchemySortMixin`
- `execute_search_query()` in both sync and async adapters
- `delete()` and `bulk_delete()` methods
- Return types for search operations now properly typed as `tuple[list[T], int]`

## Type of change

- [x] Refactoring (no functional changes, no API changes)
- [x] This change requires a documentation update

## How Has This Been Tested?

- [x] **Type Checking**: Verified MyPy compliance for the modified SQLAlchemy adapter
- [x] **Existing Tests**: All existing Behave tests continue to pass, ensuring no functional regression
- [x] **IDE Verification**: Confirmed improved type hints and IntelliSense support

The changes are purely type-related and maintain full backward compatibility. No runtime behavior is modified.

## Checklist:

- [x] My code follows the style guidelines of this project (Python 3.13 type hints with `|` unions)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (existing docstrings maintained)
- [x] My changes generate no new warnings (type-only changes)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (N/A)
- [x] I have checked my code and corrected any misspellings

## Additional context

This refactoring aligns with the project's commitment to modern Python 3.13 typing practices and follows the established patterns in the codebase. The use of `TypeVar` bound to `BaseEntity` provides:

1. **Better Type Safety**: Ensures methods return the same entity type that was passed in
2. **Enhanced Developer Experience**: Improved autocomplete and type checking in IDEs
3. **Consistency**: Aligns with the existing generic type patterns used throughout the ArchiPy codebase
4. **Future-Proofing**: Establishes a foundation for more advanced generic typing patterns

The changes maintain full compatibility with existing code while providing enhanced type safety for future development.

### Technical Details

#### Before (using BaseEntity):
```python
def execute_search_query(
    self,
    entity: type[BaseEntity],
    query: Select,
    pagination: PaginationDTO | None = None,
    sort_info: SortDTO | None = None,
    has_multiple_entities: bool = False,
) -> tuple[list[BaseEntity], int]:
```

#### After (using generic T):
```python
def execute_search_query(
    self,
    entity: type[T],
    query: Select,
    pagination: PaginationDTO | None = None,
    sort_info: SortDTO | None = None,
    has_multiple_entities: bool = False,
) -> tuple[list[T], int]:
```

This change ensures that if you pass in `User` as the entity type, the return type will be `tuple[list[User], int]` instead of the less specific `tuple[list[BaseEntity], int]`.

### Files Modified

- `archipy/adapters/base/sqlalchemy/adapters.py` - Updated type annotations for better type 