### PR TITLE
Add custom workflow ID support for Temporal scheduled workflows

### DIFF
--- a/archipy/adapters/temporal/adapters.py
+++ b/archipy/adapters/temporal/adapters.py
@@ -14,6 +14,8 @@ from temporalio.client import (
     Client,
     Schedule,
     ScheduleActionStartWorkflow,
+    ScheduleOverlapPolicy,
+    SchedulePolicy,
     ScheduleSpec,
     TLSConfig,
     WorkflowHandle,
@@ -404,17 +406,27 @@ class TemporalAdapter(TemporalPort):
             self._client = None
 
     @override
-    async def create_schedule(self, schedule_id: str, workflow_class: Any, spec: ScheduleSpec, task_queue: str) -> None:
+    async def create_schedule(
+        self,
+        schedule_id: str,
+        workflow_class: Any,
+        spec: ScheduleSpec,
+        task_queue: str,
+        workflow_id_prefix: str | None = None,
+    ) -> None:
         """Create a schedule for a workflow."""
         client = await self.get_client()
 
         sched = Schedule(
             action=ScheduleActionStartWorkflow(
                 workflow_class,
-                id=schedule_id,
+                id=workflow_id_prefix,
                 task_queue=task_queue,
             ),
             spec=spec,
+            policy=SchedulePolicy(
+                overlap=ScheduleOverlapPolicy.SKIP,
+            ),
         )
 
         await client.create_schedule(schedule_id, sched)

--- a/archipy/adapters/temporal/adapters.py
+++ b/archipy/adapters/temporal/adapters.py
@@ -412,7 +412,8 @@ class TemporalAdapter(TemporalPort):
         workflow_class: Any,
         spec: ScheduleSpec,
         task_queue: str,
-        workflow_id_prefix: str | None = None,
+        workflow_id: str | None = None,
+        schedule_policy: SchedulePolicy | None = None,
     ) -> None:
         """Create a schedule for a workflow."""
         client = await self.get_client()
@@ -420,11 +421,12 @@ class TemporalAdapter(TemporalPort):
         sched = Schedule(
             action=ScheduleActionStartWorkflow(
                 workflow_class,
-                id=workflow_id_prefix,
+                id=workflow_id,
                 task_queue=task_queue,
             ),
             spec=spec,
-            policy=SchedulePolicy(
+            policy=schedule_policy
+            or SchedulePolicy(
                 overlap=ScheduleOverlapPolicy.SKIP,
             ),
         )


### PR DESCRIPTION
Enhances the Temporal adapter's create_schedule method to support custom workflow ID prefixes and configurable overlap policies for scheduled jobs.

- Allows specifying custom workflow ID prefixes for better workflow identification and organization
- Prevents concurrent executions of the same scheduled workflow
- Ensures workflow executions don't overlap when previous runs are still in progress