### PR TITLE
fix(saman-shaparak-payment): handle missing TransactionDetail gracefu…

### DIFF
--- a/archipy/adapters/internet_payment_gateways/ir/saman/adapters.py
+++ b/archipy/adapters/internet_payment_gateways/ir/saman/adapters.py
@@ -111,7 +111,7 @@ class SamanShaparakPaymentAdapter(SamanShaparakPaymentPort):
             resp.raise_for_status()
             data = resp.json()
 
-            transaction_detail = data.get("TransactionDetail", {})
+            transaction_detail = data.get("TransactionDetail") or {}
             return VerifyResponseDTO(
                 success=data.get("Success", False),
                 result_code=data.get("ResultCode", -1),
@@ -305,7 +305,7 @@ class AsyncSamanShaparakPaymentAdapter(AsyncSamanShaparakPaymentPort):
             resp.raise_for_status()
             data = resp.json()
 
-            transaction_detail = data.get("TransactionDetail", {})
+            transaction_detail = data.get("TransactionDetail") or {}
             return VerifyResponseDTO(
                 success=data.get("Success", False),
                 result_code=data.get("ResultCode", -1),


### PR DESCRIPTION
# Handle missing TransactionDetail gracefully in Saman payment adapters

## Description

Saman verify responses can include `"TransactionDetail": null` on failed verification (for example `{"TransactionDetail": null, "ResultCode": -2, "Success": false}`). The sync and async Saman adapters used `data.get("TransactionDetail", {})`, which only substitutes when the key is missing; when the key is present with a null value, `.get()` returns `None` and the next `.get("RRN")` raises `AttributeError`. That exception is caught at the adapter boundary and re-raised as `InternalError`, so callers cannot handle a normal gateway failure from `success`, `result_code`, and `result_description`.

This change treats a null `TransactionDetail` as an empty object in both `verify_payment` implementations, so failed verifications return `VerifyResponseDTO` with optional detail fields left unset instead of raising `InternalError`.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Documentation update

## How Has This Been Tested?

- [x] `uv run ty check archipy/adapters/internet_payment_gateways/ir/saman/adapters.py` 
- [x] Pre-commit on the touched adapter file: `ruff-format`, `ruff`, `add-trailing-comma`, `validate-pyproject`, `ty`
- [ ] Automated Saman adapter BDD or unit coverage for null `TransactionDetail` (not added in this PR)
- [x] `Manual local test` 

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Additional context

`VerifyResponseDTO` already allows optional detail fields on failure; no port or DTO changes were required. Scope is limited to `archipy/adapters/internet_payment_gateways/ir/saman/adapters.py` in sync and async `verify_payment`.
